### PR TITLE
Tiled support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+/images/outputs/
+/checkpoints/
+/models/
+
+/images/content/*
+!/images/content/zurich.jpeg
+
+/images/styles/*
+!/images/styles/cuphead.jpg
+!/images/styles/mosaic.jpg
+!/images/styles/starry_night.jpg

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ I have made some trained models available [here](https://drive.google.com/drive/
 python3 train.py  --dataset_path <path-to-dataset> \
                   --style_image <path-to-style-image> \
                   --epochs 1 \
+                  --iters 10000 \
                   --batch_size 4 \
                   --image_size 256
 ```
@@ -30,7 +31,12 @@ python3 train.py  --dataset_path <path-to-dataset> \
 ```
 python3 test_on_video.py  --video_path <path-to-video> \
                           --checkpoint_model <path-to-checkpoint> \
+                          --export_type 2 \
+                          --max_size 512 \
+                          --overlap 32
 ```
+
+export_type determines how the result is saved. Its possible values are 0, for export frames only, 1 for export video only, and 2 for export both. 2 is recommended as the video export process can go wrong, and manually compressing the frames using ffmpeg command line interface can be useful as more options are available, eg. audio.
 
 <p align="center">
     <img src="assets/stylized-celtics.gif" width="400"\>
@@ -41,4 +47,12 @@ python3 test_on_video.py  --video_path <path-to-video> \
 ```
 python3 test_on_image.py  --image_path <path-to-image> \
                           --checkpoint_model <path-to-checkpoint> \
+                          --max_size 512 \
+                          --overlap 32
 ```
+
+## Tiled images for smaller GPUs
+
+max_size and overlap are optional arguments. If max_size is specified, then the image is split into a number of square tiles. Each tile is processed individually and then the image is stitched back together at the end. Max size is the maximum width of a square image your GPU can process at one time. Find this through experimentation. First try without wither option, and if you get an out of memory error, make the max_size something like 1024 or 512, and keep decreasing it until it works. overlap is the extra number of pixels added onto either side for a smooth transition to the next tile.
+
+--octave_num and --octave_scale are also availiable. A smaller image is processed then scaled up by octave_scale, and then processed again. This is repeated octave_num times until it reaches the original size. This is similar to some DeepDream code. It was a bit of an experiment and it looks terrible, but try it if you want.

--- a/models.py
+++ b/models.py
@@ -84,7 +84,7 @@ class ConvBlock(torch.nn.Module):
 
     def forward(self, x):
         if self.upsample:
-            x = F.interpolate(x, scale_factor=2)
+            x = F.upsample(x, scale_factor=2)
         x = self.block(x)
         if self.norm is not None:
             x = self.norm(x)

--- a/test_on_image.py
+++ b/test_on_image.py
@@ -7,33 +7,184 @@ import os
 import tqdm
 from torchvision.utils import save_image
 from PIL import Image
+import numpy as np
+from imageio import imwrite
+from math import floor
+from datetime import datetime
+
+
+class Stylizer:
+    def __init__(self, model_path):
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.transform = style_transform()
+
+        # Define model and load model checkpoint
+        self.transformer = TransformerNet().to(self.device)
+        self.transformer.load_state_dict(torch.load(model_path))
+        self.transformer.eval()
+
+    def get_index(self, x, tile, max_size, overlap):
+        # Given a coordinate in the final image, what is the coordinate of the pixel
+        # in the tile at that location
+        return x if tile==0 else x-(tile*max_size)+overlap
+
+    def do_section(self, section):
+        # Prepare input
+        image_tensor = Variable(self.transform(Image.fromarray(np.uint8(section)))).to(self.device)
+        image_tensor = image_tensor.unsqueeze(0)
+
+        # Stylize image
+        with torch.no_grad():
+            stylized_array = deprocess(self.transformer(image_tensor))[:section.shape[0], :section.shape[1], :]
+
+        return stylized_array
+
+    def stylize_image(self, input_image, max_size=0, overlap=32):
+        input_array = np.asarray(input_image, dtype='float32')
+        if max_size != 0:
+            width, height = input_array.shape[1::-1]
+            wtiles = width // max_size + 1
+            htiles = height // max_size + 1
+
+            print('width: %i height: %i horizontal tiles: %i vertical tiles %i' % (width, height, wtiles, htiles))
+
+            zeros = np.zeros(shape=(1,1), dtype='float32')
+
+            arrayOfImages = [[zeros for x in range(wtiles)] for y in range(htiles)]
+
+            x_domains = [[0, 0] for x in range(wtiles)]
+            y_domains = [[0, 0] for y in range(htiles)]
+
+
+            for j in range(htiles):
+                for i in range(wtiles):
+                    # boundaries of tile
+                    x1 = max_size * i
+                    x2 = min(width, max_size*(i+1))
+                    y1 = max_size * j
+                    y2 = min(height, max_size*(j+1))
+
+                    # how many extra pixels on each side to compute
+                    o_left = overlap if i > 0 else 0
+                    o_right = overlap if i < wtiles-1 else 0
+                    o_top = overlap if j > 0 else 0
+                    o_bottom = overlap if j < htiles-1 else 0
+
+                    # final boundaries of the window that will be computed
+                    ox1 = x1 - o_left
+                    ox2 = x2 + o_right
+                    oy1 = y1 - o_top
+                    oy2 = y2 + o_bottom
+
+                    print(f'Tile({x1},{x2},{y1},{y2})')
+
+                    # style transfer the current window
+                    arrayOfImages[j][i] = self.do_section(input_array[oy1:oy2, ox1:ox2, :])
+
+                    # store some boundaries for later. These are the coordinates in the
+                    # final image within which only one tile will be used and without
+                    # which will be a blend between multiple tiles.
+                    if j==0:
+                        x_domains[i][0] = x1 + o_left
+                        x_domains[i][1] = x2 - o_right
+                    if i==0:
+                        y_domains[j][0] = y1 + o_top
+                        y_domains[j][1] = y2 - o_bottom
+
+            arrayOfRows = [zeros for y in range(htiles)]
+
+            for j in range(htiles):
+                row_array = np.zeros(shape=(arrayOfImages[j][0].shape[0], width, 3), dtype='float32')
+                xfactors = np.zeros(shape=(width), dtype='float32')
+                for x in range(width):
+                    #find which tiles should be used
+                    for i in range(len(x_domains)):
+                        if i==len(x_domains)-1:
+                            xfactors[x]=i
+                        elif x >= x_domains[i][0] and x < x_domains[i+1][0]:
+                            if x < x_domains[i][1]:
+                                xfactors[x] = i
+                            else:
+                                xfactors[x] = (x-x_domains[i][1])/(2*overlap) + i
+                            break
+
+                    #if using only one tile just simply use it
+                    if float(xfactors[x]).is_integer():
+                        row_array[:, x, :] = arrayOfImages[j][int(xfactors[x])][:, self.get_index(x, int(floor(xfactors[x])), max_size, overlap), :]
+                    #if using two tiles compute the factor for each tile and blend them
+                    else:
+                        muld_lower = arrayOfImages[j][int(floor(xfactors[x]))][:, self.get_index(x, int(floor(xfactors[x])), max_size, overlap), :] * (1-xfactors[x]%1)
+                        muld_higher = arrayOfImages[j][int(floor(xfactors[x]+1))][:, self.get_index(x, int(floor(xfactors[x]+1)), max_size, overlap), :] * ((xfactors[x]%1))
+                        row_array[:, x, :] = muld_lower + muld_higher
+                arrayOfRows[j] = row_array
+
+
+            final_image = np.zeros(shape=(height, width, 3), dtype='float32')
+            yfactors = np.zeros(shape=(height), dtype='float32')
+            for y in range(height):
+                #find which tiles should be used
+                for j in range(len(y_domains)):
+                    if j==len(y_domains)-1:
+                        yfactors[y]=j
+                    elif y >= y_domains[j][0] and y < y_domains[j+1][0]:
+                        if y < y_domains[j][1]:
+                            yfactors[y] = j
+                        else:
+                            yfactors[y] = (y-y_domains[j][1])/(2*overlap) + j
+                        break
+
+                #if using only one row just simply use it
+                if float(yfactors[y]).is_integer():
+                    final_image[y, :, :] = arrayOfRows[int(floor(yfactors[y]))][self.get_index(y, int(floor(yfactors[y])), max_size, overlap), :, :]
+                #if using two rows compute the factor for each row and blend them
+                else:
+                    muld_lower = arrayOfRows[int(floor(yfactors[y]))][self.get_index(y, int(floor(yfactors[y])), max_size, overlap), :, :] * (1-yfactors[y]%1)
+                    muld_higher = arrayOfRows[int(floor(yfactors[y]+1))][self.get_index(y, int(floor(yfactors[y]+1)), max_size, overlap), :, :] * ((yfactors[y]%1))
+                    final_image[y, :, :] = muld_lower + muld_higher
+
+            return Image.fromarray(final_image.astype(np.uint8))
+        else:
+            return Image.fromarray(self.do_section(input_array).astype(np.uint8))
+
+    def stylize_with_octaves(self, input_image, max_size=0, overlap=32, octaves=4, octave_scale=1.4):
+        original = input_image
+        input_image = scale_factor(input_image, (1/octave_scale) ** octaves)
+        for octave in range(octaves):
+            input_image = scale_factor(self.stylize_image(input_image, max_size, overlap), octave_scale)
+            scaled_original = scale_absolute(original, input_image.size[0], input_image.size[1])
+            input_image = Image.blend(input_image, scaled_original, 0.5)
+        return self.stylize_image(input_image, max_size, overlap)
+
+
+def save(name, array):
+    Image.fromarray(array.astype(np.uint8)).save(f"images/outputs/{name}")
 
 if __name__ == "__main__":
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--image_path", type=str, required=True, help="Path to image")
-    parser.add_argument("--checkpoint_model", type=str, required=True, help="Path to checkpoint model")
+    parser.add_argument('--image_path', '-i', type=str, required=True, help="Path to image")
+    parser.add_argument('--checkpoint_model', '-c', type=str, required=True, help="Path to checkpoint model")
+    parser.add_argument('--max_size', '-m', type=int, default=0, help="Tile size")
+    parser.add_argument('--overlap', '-o', type=int, default=32, help="Overlap between tiles")
+    parser.add_argument('--octave_num', '-on', type=int, default=None, help="Number of octaves")
+    parser.add_argument('--octave_scale', '-os', type=float, default=1.4, help="Scale between octaves")
+
+
     args = parser.parse_args()
     print(args)
 
     os.makedirs("images/outputs", exist_ok=True)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    transform = style_transform()
-
-    # Define model and load model checkpoint
-    transformer = TransformerNet().to(device)
-    transformer.load_state_dict(torch.load(args.checkpoint_model))
-    transformer.eval()
-
-    # Prepare input
-    image_tensor = Variable(transform(Image.open(args.image_path))).to(device)
-    image_tensor = image_tensor.unsqueeze(0)
-
-    # Stylize image
-    with torch.no_grad():
-        stylized_image = denormalize(transformer(image_tensor)).cpu()
+    stylizer = Stylizer(args.checkpoint_model)
+    stylized_image = Image.open(args.image_path)
+    if args.octave_num:
+        stylized_image = stylizer.stylize_with_octaves(stylized_image, args.max_size, args.overlap, args.octave_num, args.octave_scale)
+    else:
+        stylized_image = stylizer.stylize_image(stylized_image, args.max_size, args.overlap)
 
     # Save image
-    fn = args.image_path.split("/")[-1]
-    save_image(stylized_image, f"images/outputs/stylized-{fn}")
+    fn = args.image_path.split('/')[-1]
+    now = datetime.now()
+    print(fn)
+    save(f"{now.year}{now.month}{now.day}-{now.hour}{now.minute}{now.second}-{args.checkpoint_model.split('/')[-1].split('.')[0]}-styled-{fn}", np.asarray(stylized_image, dtype='float32'))

--- a/test_on_video.py
+++ b/test_on_video.py
@@ -4,41 +4,54 @@ import torch
 from torch.autograd import Variable
 import argparse
 import os
-import tqdm
 from PIL import Image
-import skvideo.io
+import tqdm
+from moviepy.video.io.VideoFileClip import VideoFileClip
+import moviepy.video.io.ffmpeg_writer as ffmpeg_writer
+from test_on_image import Stylizer, save
+from datetime import datetime
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--video_path", type=str, required=True, help="Path to video")
-    parser.add_argument("--checkpoint_model", type=str, required=True, help="Path to checkpoint model")
+    parser.add_argument('--video_path', '-v', type=str, required=True, help='Path to video')
+    parser.add_argument('--checkpoint_model', '-c', type=str, required=True, help='Path to checkpoint model')
+    parser.add_argument('--export_type', '-e', type=int, required=True, choices=[0,1,2], help='What to export? 0 for just frames, 1 for just video, 2 for both. 2 is recommended in case something goes wrong with the video.')
+    parser.add_argument('--max_size', '-m', type=int, default=0, help='Tile size')
+    parser.add_argument('--overlap', '-o', type=int, default=32, help='Overlap between tiles')
+    parser.add_argument('--octave_num', '-on', type=int, default=None, help="Number of octaves")
+    parser.add_argument('--octave_scale', '-os', type=float, default=1.4, help="Scale between octaves")
     args = parser.parse_args()
     print(args)
 
-    os.makedirs("images/outputs", exist_ok=True)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    transform = style_transform()
-
-    # Define model and load model checkpoint
-    transformer = TransformerNet().to(device)
-    transformer.load_state_dict(torch.load(args.checkpoint_model))
-    transformer.eval()
-
-    stylized_frames = []
-    for frame in tqdm.tqdm(extract_frames(args.video_path), desc="Processing frames"):
-        # Prepare input frame
-        image_tensor = Variable(transform(frame)).to(device).unsqueeze(0)
-        # Stylize image
-        with torch.no_grad():
-            stylized_image = transformer(image_tensor)
-        # Add to frames
-        stylized_frames += [deprocess(stylized_image)]
+    stylizer = Stylizer(args.checkpoint_model)
+    video_clip = VideoFileClip(args.video_path, audio=False)
+    now = datetime.now()
+    video_name = args.video_path.split("/")[-1].split(".")[0]
+    out_dir = f"{now.year}{now.month}{now.day}-{now.hour}{now.minute}{now.second}-{args.checkpoint_model.split('/')[-1].split('.')[0]}-styled-{video_name}"
+    os.makedirs(f"images/outputs/{out_dir}", exist_ok=True)
 
     # Create video from frames
-    video_name = args.video_path.split("/")[-1].split(".")[0]
-    writer = skvideo.io.FFmpegWriter(f"images/outputs/stylized-{video_name}.gif")
-    for frame in tqdm.tqdm(stylized_frames, desc="Writing to video"):
-        writer.writeFrame(frame)
-    writer.close()
+    video_writer = None
+    if args.export_type != 0:
+        video_writer = ffmpeg_writer.FFMPEG_VideoWriter(f'images/outputs/{out_dir}/{video_name}.mp4', video_clip.size, video_clip.fps, codec="libx264",
+                                                        preset="medium", bitrate="2000k",
+                                                        audiofile=None, threads=None,
+                                                        ffmpeg_params=None)
+
+    try:
+        fnum=0
+        stylized_frames = []
+        for frame in tqdm.tqdm(video_clip.iter_frames(), desc="Processing frames"):
+            outframe = stylizer.stylize_with_octaves(frame, args.max_size, args.overlap, args.octave_num, args.octave_scale) if args.octave_num else stylizer.stylize_image(frame, args.max_size, args.overlap)
+            if args.export_type != 0:
+                video_writer.write_frame(outframe)
+            if args.export_type != 1:
+                save(f"{out_dir}/frame_{fnum}.jpg", np.asarray(outframe, dtype='float32'))
+                save(f"{out_dir}/latest.jpg", np.asarray(outframe, dtype='float32')) #open image viewer on this to see video progress along
+            fnum+=1
+
+        video_writer.close()
+    except KeyboardInterrupt:
+        video_writer.close()

--- a/utils.py
+++ b/utils.py
@@ -2,11 +2,19 @@ from torchvision import transforms
 import torch
 import numpy as np
 import av
+from math import floor
 
 # Mean and standard deviation used for pre-trained PyTorch models
 mean = np.array([0.485, 0.456, 0.406])
 std = np.array([0.229, 0.224, 0.225])
 
+def scale_factor(image, factor):
+    """ Scales image by a factor """
+    return transforms.Resize(int(floor(min(image.size[0], image.size[1]) * factor)))(image)
+
+def scale_absolute(image, width, height):
+    """ Uniformly scales an image to fit width """
+    return transforms.Resize((height, width))(image)
 
 def extract_frames(video_path):
     """ Extracts frames from video """
@@ -44,6 +52,11 @@ def style_transform(image_size=None):
     transform = transforms.Compose(resize + [transforms.ToTensor(), transforms.Normalize(mean, std)])
     return transform
 
+def square_image(image, image_size=None):
+    """ Returns the largest square from the given image, then resized """
+    if image_size:
+        image = transforms.Resize(image_size)(image)
+    return transforms.CenterCrop(min(image.size[0], image.size[1]))(image)
 
 def denormalize(tensors):
     """ Denormalizes image tensors using mean and std """


### PR DESCRIPTION
The image can be divided into smaller tiles using the max_size option. Each tile is processed separately and blended together using the overlap option. More detail in the README.md

Also, a .gitignore has been added.

The video processing uses moviepy rather than skvideo to write the video, for now. I had some trouble with skvideo, but moviepy doesn't seem to be working properly either. The video greatly drops in quality after a few seconds. The frame-by-frame export works fine, so there is an option to just export frames and manually compress into a video. I will try to get it working properly before marking this as ready for review. 

This should go into a new branch other than master but I couldn't figure out how to put that in the request... I'm a bit of a Github noob. 